### PR TITLE
[FEAT]: SMS Consumer 세부 로직 코드 작성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,8 +30,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
-
     implementation 'org.springframework.kafka:spring-kafka'
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 
     // DB
     runtimeOnly 'org.postgresql:postgresql'

--- a/src/main/java/com/example/only4_kafka/domain/bill/Bill.java
+++ b/src/main/java/com/example/only4_kafka/domain/bill/Bill.java
@@ -6,7 +6,6 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
-
 import java.math.BigDecimal;
 import java.time.LocalDate;
 
@@ -73,5 +72,9 @@ public class Bill extends BaseEntity {
         if (unpaidAmount == null) unpaidAmount = BigDecimal.ZERO;
         if (totalDiscountAmount == null) totalDiscountAmount = BigDecimal.ZERO;
         if (totalBilledAmount == null) totalBilledAmount = BigDecimal.ZERO;
+    }
+
+    public void changeSendStatus(BillSendStatus sendStatus) {
+        this.billSendStatus = sendStatus;
     }
 }

--- a/src/main/java/com/example/only4_kafka/domain/bill/Bill.java
+++ b/src/main/java/com/example/only4_kafka/domain/bill/Bill.java
@@ -1,0 +1,77 @@
+package com.example.only4_kafka.domain.bill;
+
+import com.example.only4_kafka.domain.common.BaseEntity;
+import com.example.only4_kafka.domain.member.Member;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+@Entity
+@Table(name = "bill")
+public class Bill extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false, updatable = false)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "member_id", nullable = false,
+            foreignKey = @ForeignKey(name = "fk_bill_to_member"))
+    private Member member;
+
+    @Column(name = "billing_year_month", nullable = false)
+    private LocalDate billingYearMonth;
+
+    @Column(name = "total_amount", nullable = false, precision = 18, scale = 0)
+    private BigDecimal totalAmount;
+
+    @Column(name = "vat", nullable = false, precision = 18, scale = 0)
+    private BigDecimal vat;
+
+    @Column(name = "unpaid_amount", nullable = false, precision = 18, scale = 0)
+    private BigDecimal unpaidAmount;
+
+    @Column(name = "total_discount_amount", nullable = false, precision = 18, scale = 0)
+    private BigDecimal totalDiscountAmount;
+
+    @Column(name = "total_billed_amount", nullable = false, precision = 18, scale = 0)
+    private BigDecimal totalBilledAmount;
+
+    @Column(name = "due_date")
+    private LocalDate dueDate;
+
+    @Column(name = "approval_expected_date")
+    private LocalDate approvalExpectedDate;
+
+    @Enumerated(EnumType.STRING)
+    @JdbcTypeCode(SqlTypes.NAMED_ENUM)
+    @Column(name = "bill_send_status", columnDefinition = "bill_send_status_enum")
+    private BillSendStatus billSendStatus;
+
+    @Column(name = "payment_owner_name_snapshot", nullable = false, length = 100)
+    private String paymentOwnerNameSnapshot;
+
+    @Column(name = "payment_name_snapshot", nullable = false, length = 100)
+    private String paymentNameSnapshot;
+
+    @Column(name = "payment_number_snapshot", nullable = false, length = 100)
+    private String paymentNumberSnapshot;
+
+    @PrePersist
+    private void prePersist() {
+        if (totalAmount == null) totalAmount = BigDecimal.ZERO;
+        if (vat == null) vat = BigDecimal.ZERO;
+        if (unpaidAmount == null) unpaidAmount = BigDecimal.ZERO;
+        if (totalDiscountAmount == null) totalDiscountAmount = BigDecimal.ZERO;
+        if (totalBilledAmount == null) totalBilledAmount = BigDecimal.ZERO;
+    }
+}

--- a/src/main/java/com/example/only4_kafka/domain/bill/BillRepository.java
+++ b/src/main/java/com/example/only4_kafka/domain/bill/BillRepository.java
@@ -1,0 +1,10 @@
+package com.example.only4_kafka.domain.bill;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface BillRepository extends JpaRepository<Bill, Long> {
+}

--- a/src/main/java/com/example/only4_kafka/domain/bill/BillRepository.java
+++ b/src/main/java/com/example/only4_kafka/domain/bill/BillRepository.java
@@ -1,10 +1,39 @@
 package com.example.only4_kafka.domain.bill;
 
+import com.example.only4_kafka.domain.bill_send.SmsBillDto;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
 @Repository
 public interface BillRepository extends JpaRepository<Bill, Long> {
+    @Query("""
+        SELECT SmsBillDto(
+            m.name,
+            m.phoneNumber,
+            m.doNotDisturbStartTime,
+            m.doNotDisturbEndTime,
+            
+            b.paymentOwnerNameSnapshot,
+            b.paymentNameSnapshot,
+            b.paymentNumberSnapshot,
+            b.dueDate,
+
+            b.id,
+            b.billingYearMonth,
+            b.totalAmount,
+            b.totalDiscountAmount,
+            b.unpaidAmount,
+            b.totalBilledAmount,
+            b.vat,
+            CURRENT_DATE
+        )
+        FROM Bill b
+        JOIN b.member m
+        WHERE b.id = :billId
+    """)
+    Optional<SmsBillDto> findSmsBillDtoById(@Param("billId") Long billId);
 }

--- a/src/main/java/com/example/only4_kafka/domain/bill/BillSendStatus.java
+++ b/src/main/java/com/example/only4_kafka/domain/bill/BillSendStatus.java
@@ -1,0 +1,5 @@
+package com.example.only4_kafka.domain.bill;
+
+public enum BillSendStatus {
+    BEFORE_SENT, SENT, FAILED
+}

--- a/src/main/java/com/example/only4_kafka/domain/bill_item/BillItem.java
+++ b/src/main/java/com/example/only4_kafka/domain/bill_item/BillItem.java
@@ -1,0 +1,56 @@
+package com.example.only4_kafka.domain.bill_item;
+
+import com.example.only4_kafka.domain.bill.Bill;
+import com.example.only4_kafka.domain.common.BaseEntity;
+import com.example.only4_kafka.domain.product.BillItemSubcategory;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.math.BigDecimal;
+import java.util.Map;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+@Entity
+@Table(name = "bill_item")
+public class BillItem extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false, updatable = false)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "bill_id", nullable = false,
+            foreignKey = @ForeignKey(name = "fk_bill_item_to_bill"))
+    private Bill bill;
+
+    @Enumerated(EnumType.STRING)
+    @JdbcTypeCode(SqlTypes.NAMED_ENUM)
+    @Column(name = "item_category", nullable = false, columnDefinition = "bill_item_category_enum")
+    private BillItemCategory itemCategory;
+
+    @Enumerated(EnumType.STRING)
+    @JdbcTypeCode(SqlTypes.NAMED_ENUM)
+    @Column(name = "item_subcategory", columnDefinition = "bill_item_subcategory_enum")
+    private BillItemSubcategory itemSubcategory;
+
+    @Column(name = "item_name", nullable = false, length = 255)
+    private String itemName;
+
+    @Column(name = "amount", nullable = false, precision = 18, scale = 0)
+    private BigDecimal amount;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "detail_snapshot", columnDefinition = "jsonb")
+    private Map<String, Object> detailSnapshot;
+
+    @PrePersist
+    private void prePersist() {
+        if (amount == null) amount = BigDecimal.ZERO;
+    }
+}

--- a/src/main/java/com/example/only4_kafka/domain/bill_item/BillItemCategory.java
+++ b/src/main/java/com/example/only4_kafka/domain/bill_item/BillItemCategory.java
@@ -1,0 +1,6 @@
+package com.example.only4_kafka.domain.bill_item;
+
+public enum BillItemCategory {
+
+    SUBSCRIPTION, OVER_USAGE, ONE_TIME_PURCHASE, DISCOUN
+}

--- a/src/main/java/com/example/only4_kafka/domain/bill_item/BillItemRepository.java
+++ b/src/main/java/com/example/only4_kafka/domain/bill_item/BillItemRepository.java
@@ -1,0 +1,8 @@
+package com.example.only4_kafka.domain.bill_item;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface BillItemRepository extends JpaRepository<BillItem, Long> {
+}

--- a/src/main/java/com/example/only4_kafka/domain/bill_notification/BillChannel.java
+++ b/src/main/java/com/example/only4_kafka/domain/bill_notification/BillChannel.java
@@ -1,0 +1,5 @@
+package com.example.only4_kafka.domain.bill_notification;
+
+public enum BillChannel {
+    EMAIL, SMS
+}

--- a/src/main/java/com/example/only4_kafka/domain/bill_notification/BillNotification.java
+++ b/src/main/java/com/example/only4_kafka/domain/bill_notification/BillNotification.java
@@ -1,0 +1,37 @@
+package com.example.only4_kafka.domain.bill_notification;
+
+import com.example.only4_kafka.domain.bill.Bill;
+import com.example.only4_kafka.domain.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+@Entity
+@Table(name = "bill_notification")
+public class BillNotification extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false, updatable = false)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "bill_id", nullable = false,
+            foreignKey = @ForeignKey(name = "fk_bill_notification_to_bill"))
+    private Bill bill;
+
+    @Enumerated(EnumType.STRING)
+    @JdbcTypeCode(SqlTypes.NAMED_ENUM)
+    @Column(name = "channel", nullable = false, columnDefinition = "bill_channel_enum")
+    private BillChannel channel;
+
+    @Enumerated(EnumType.STRING)
+    @JdbcTypeCode(SqlTypes.NAMED_ENUM)
+    @Column(name = "send_status", nullable = false, columnDefinition = "bill_notification_status_enum")
+    private BillNotificationStatus sendStatus;
+}

--- a/src/main/java/com/example/only4_kafka/domain/bill_notification/BillNotification.java
+++ b/src/main/java/com/example/only4_kafka/domain/bill_notification/BillNotification.java
@@ -34,4 +34,8 @@ public class BillNotification extends BaseEntity {
     @JdbcTypeCode(SqlTypes.NAMED_ENUM)
     @Column(name = "send_status", nullable = false, columnDefinition = "bill_notification_status_enum")
     private BillNotificationStatus sendStatus;
+
+    public void changeSendStatus(BillNotificationStatus sendStatus) {
+        this.sendStatus = sendStatus;
+    }
 }

--- a/src/main/java/com/example/only4_kafka/domain/bill_notification/BillNotificationRepository.java
+++ b/src/main/java/com/example/only4_kafka/domain/bill_notification/BillNotificationRepository.java
@@ -1,0 +1,8 @@
+package com.example.only4_kafka.domain.bill_notification;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface BillNotificationRepository extends JpaRepository<BillNotification, Long> {
+}

--- a/src/main/java/com/example/only4_kafka/domain/bill_notification/BillNotificationRepository.java
+++ b/src/main/java/com/example/only4_kafka/domain/bill_notification/BillNotificationRepository.java
@@ -5,4 +5,6 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface BillNotificationRepository extends JpaRepository<BillNotification, Long> {
+    // 청구서의 발송 상태 (READY, SENT, FAILED) 확인
+    boolean existsByBillIdAndSendStatus(Long billId, BillNotificationStatus sendStatus);
 }

--- a/src/main/java/com/example/only4_kafka/domain/bill_notification/BillNotificationStatus.java
+++ b/src/main/java/com/example/only4_kafka/domain/bill_notification/BillNotificationStatus.java
@@ -1,0 +1,5 @@
+package com.example.only4_kafka.domain.bill_notification;
+
+public enum BillNotificationStatus {
+    READY, SENT, FAILED
+}

--- a/src/main/java/com/example/only4_kafka/domain/bill_send/SmsBillDto.java
+++ b/src/main/java/com/example/only4_kafka/domain/bill_send/SmsBillDto.java
@@ -1,0 +1,32 @@
+package com.example.only4_kafka.domain.bill_send;
+
+import com.example.only4_kafka.domain.receipt.PaymentMethod;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public record SmsBillDto(
+        // 고객 정보
+        String name,
+        String phoneNumber,
+        LocalTime doNotDisturbStartTime,
+        LocalTime doNotDisturbEndTime,
+
+        // 납부 정보
+        String paymentOwnerName,
+        String paymentName,
+        String paymentNumber,
+        LocalDate dueDate, // 납기일
+
+        // 명세서 정보
+        Long billId,
+        LocalDate billingYearMonth, // 청구연월
+        BigDecimal totalAmount, // 총 사용 금액
+        BigDecimal totalDiscountAmount, // 총 할인 금액
+        BigDecimal unpaidAmount, // 미납금
+        BigDecimal totalBilledAmount, // 총 청구 금액 (실제 납부)
+        BigDecimal vat, // 부가가치세
+        LocalDate createdDate // 작성 일자
+) {
+}

--- a/src/main/java/com/example/only4_kafka/domain/member/Member.java
+++ b/src/main/java/com/example/only4_kafka/domain/member/Member.java
@@ -1,0 +1,64 @@
+package com.example.only4_kafka.domain.member;
+
+import com.example.only4_kafka.domain.common.BaseEntity;
+import com.example.only4_kafka.domain.receipt.PaymentMethod;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.time.LocalTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+@Entity
+@Table(name = "member")
+public class Member extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false, updatable = false)
+    private Long id;
+
+    @Column(name = "name", nullable = false, length = 50)
+    private String name;
+
+    @Column(name = "phone_number", nullable = false, length = 255)
+    private String phoneNumber;
+
+    @Column(name = "email", nullable = false, length = 255)
+    private String email;
+
+    @Column(name = "address", nullable = false, length = 255)
+    private String address;
+
+    @Enumerated(EnumType.STRING)
+    @JdbcTypeCode(SqlTypes.NAMED_ENUM)
+    @Column(name = "member_grade", nullable = false, columnDefinition = "member_grade_enum")
+    private MemberGrade memberGrade;
+
+    @Column(name = "payment_owner_name", nullable = false, length = 100)
+    private String paymentOwnerName;
+
+    @Column(name = "payment_name", nullable = false, length = 100)
+    private String paymentName;
+
+    @Column(name = "payment_number", nullable = false, length = 100)
+    private String paymentNumber;
+
+    @Enumerated(EnumType.STRING)
+    @JdbcTypeCode(SqlTypes.NAMED_ENUM)
+    @Column(name = "payment_method", nullable = false, columnDefinition = "payment_method_enum")
+    private PaymentMethod paymentMethod;
+
+    @Column(name = "notification_day_of_month")
+    private Short notificationDayOfMonth;
+
+    @Column(name = "do_not_disturb_start_time")
+    private LocalTime doNotDisturbStartTime;
+
+    @Column(name = "do_not_disturb_end_time")
+    private LocalTime doNotDisturbEndTime;
+}

--- a/src/main/java/com/example/only4_kafka/domain/member/MemberGrade.java
+++ b/src/main/java/com/example/only4_kafka/domain/member/MemberGrade.java
@@ -1,0 +1,5 @@
+package com.example.only4_kafka.domain.member;
+
+public enum MemberGrade {
+    NORMAL, VIP, VVIP
+}

--- a/src/main/java/com/example/only4_kafka/domain/member/MemberRepository.java
+++ b/src/main/java/com/example/only4_kafka/domain/member/MemberRepository.java
@@ -1,0 +1,10 @@
+package com.example.only4_kafka.domain.member;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}

--- a/src/main/java/com/example/only4_kafka/domain/product/AddonSpec.java
+++ b/src/main/java/com/example/only4_kafka/domain/product/AddonSpec.java
@@ -1,0 +1,36 @@
+package com.example.only4_kafka.domain.product;
+
+import com.example.only4_kafka.domain.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.math.BigDecimal;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+@Entity
+@Table(name = "addon_spec")
+public class AddonSpec extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false, updatable = false)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "product_id", nullable = false,
+            foreignKey = @ForeignKey(name = "fk_addon_spec_to_product"))
+    private Product product;
+
+    @Enumerated(EnumType.STRING)
+    @JdbcTypeCode(SqlTypes.NAMED_ENUM)
+    @Column(name = "unit_type", nullable = false, columnDefinition = "unit_type_enum")
+    private UnitType unitType;
+
+    @Column(name = "unit_price_amount", nullable = false, precision = 18, scale = 0)
+    private BigDecimal unitPriceAmount;
+}

--- a/src/main/java/com/example/only4_kafka/domain/product/BillItemSubcategory.java
+++ b/src/main/java/com/example/only4_kafka/domain/product/BillItemSubcategory.java
@@ -1,0 +1,9 @@
+package com.example.only4_kafka.domain.product;
+
+public enum BillItemSubcategory {
+
+    PLAN, ADDON, TV,
+    DATA_OVER, VOICE_OVER, SMS_OVER, ADDON_OVER,
+    MICRO_PAYMENT, CONTENT_FEE,
+    SELECTIVE_CONTRACT, FAMILY_BUNDLE, PROMOTION, ETC
+}

--- a/src/main/java/com/example/only4_kafka/domain/product/BillingType.java
+++ b/src/main/java/com/example/only4_kafka/domain/product/BillingType.java
@@ -1,0 +1,5 @@
+package com.example.only4_kafka.domain.product;
+
+public enum BillingType {
+    RECURRING, PER_USE
+}

--- a/src/main/java/com/example/only4_kafka/domain/product/MobilePlanSpec.java
+++ b/src/main/java/com/example/only4_kafka/domain/product/MobilePlanSpec.java
@@ -1,0 +1,35 @@
+package com.example.only4_kafka.domain.product;
+
+import com.example.only4_kafka.domain.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+@Entity
+@Table(name = "mobile_plan_spec")
+public class MobilePlanSpec extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false, updatable = false)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "product_id", nullable = false,
+            foreignKey = @ForeignKey(name = "fk_mobile_plan_spec_to_product"))
+    private Product product;
+
+    @Column(name = "data_gb", precision = 10, scale = 3)
+    private BigDecimal dataGb;
+
+    @Column(name = "voice_minutes")
+    private Integer voiceMinutes;
+
+    @Column(name = "sms_count")
+    private Integer smsCount;
+}

--- a/src/main/java/com/example/only4_kafka/domain/product/Product.java
+++ b/src/main/java/com/example/only4_kafka/domain/product/Product.java
@@ -1,0 +1,39 @@
+package com.example.only4_kafka.domain.product;
+
+import com.example.only4_kafka.domain.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.math.BigDecimal;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+@Entity
+@Table(name = "product")
+public class Product extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false, updatable = false)
+    private Long id;
+
+    @Column(name = "name", nullable = false, length = 255)
+    private String name;
+
+    @Column(name = "price_amount", nullable = false, precision = 18, scale = 0)
+    private BigDecimal priceAmount;
+
+    @Enumerated(EnumType.STRING)
+    @JdbcTypeCode(SqlTypes.NAMED_ENUM)
+    @Column(name = "billing_type", nullable = false, columnDefinition = "billing_type_enum")
+    private BillingType billingType;
+
+    @Enumerated(EnumType.STRING)
+    @JdbcTypeCode(SqlTypes.NAMED_ENUM)
+    @Column(name = "product_type", nullable = false, columnDefinition = "product_type_enum")
+    private ProductType productType;
+}

--- a/src/main/java/com/example/only4_kafka/domain/product/ProductType.java
+++ b/src/main/java/com/example/only4_kafka/domain/product/ProductType.java
@@ -1,0 +1,5 @@
+package com.example.only4_kafka.domain.product;
+
+public enum ProductType {
+    MOBILE_PLAN, ADDON, TV
+}

--- a/src/main/java/com/example/only4_kafka/domain/product/TvSpec.java
+++ b/src/main/java/com/example/only4_kafka/domain/product/TvSpec.java
@@ -1,0 +1,27 @@
+package com.example.only4_kafka.domain.product;
+
+import com.example.only4_kafka.domain.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+@Entity
+@Table(name = "tv_spec")
+public class TvSpec extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false, updatable = false)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "product_id", nullable = false,
+            foreignKey = @ForeignKey(name = "fk_tv_spec_to_product"))
+    private Product product;
+
+    @Column(name = "channel_count", nullable = false)
+    private Integer channelCount;
+}

--- a/src/main/java/com/example/only4_kafka/domain/product/UnitType.java
+++ b/src/main/java/com/example/only4_kafka/domain/product/UnitType.java
@@ -1,0 +1,5 @@
+package com.example.only4_kafka.domain.product;
+
+public enum UnitType {
+    GB, MIN, COUNT
+}

--- a/src/main/java/com/example/only4_kafka/domain/receipt/PaymentMethod.java
+++ b/src/main/java/com/example/only4_kafka/domain/receipt/PaymentMethod.java
@@ -1,0 +1,5 @@
+package com.example.only4_kafka.domain.receipt;
+
+public enum PaymentMethod {
+    CARD, BANK_TRANSFER, AUTO_DEBIT
+}

--- a/src/main/java/com/example/only4_kafka/domain/receipt/Receipt.java
+++ b/src/main/java/com/example/only4_kafka/domain/receipt/Receipt.java
@@ -1,0 +1,46 @@
+package com.example.only4_kafka.domain.receipt;
+
+import com.example.only4_kafka.domain.bill.Bill;
+import com.example.only4_kafka.domain.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+@Entity
+@Table(name = "receipt")
+public class Receipt extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false, updatable = false)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "bill_id", nullable = false,
+            foreignKey = @ForeignKey(name = "fk_receipt_to_bill"))
+    private Bill bill;
+
+    @Column(name = "paid_at", nullable = false)
+    private LocalDateTime paidAt;
+
+    @Enumerated(EnumType.STRING)
+    @JdbcTypeCode(SqlTypes.NAMED_ENUM)
+    @Column(name = "payment_method", nullable = false, columnDefinition = "payment_method_enum")
+    private PaymentMethod paymentMethod;
+
+    @Column(name = "paid_amount", nullable = false, precision = 18, scale = 0)
+    private BigDecimal paidAmount;
+
+    @PrePersist
+    private void prePersist() {
+        if (paidAmount == null) paidAmount = BigDecimal.ZERO;
+    }
+}

--- a/src/main/java/com/example/only4_kafka/global/config/ThymeleafConfig.java
+++ b/src/main/java/com/example/only4_kafka/global/config/ThymeleafConfig.java
@@ -1,0 +1,29 @@
+package com.example.only4_kafka.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.thymeleaf.spring6.SpringTemplateEngine;
+import org.thymeleaf.templatemode.TemplateMode;
+import org.thymeleaf.templateresolver.ClassLoaderTemplateResolver;
+
+@Configuration
+public class ThymeleafConfig {
+
+    // Thymeleaf 템플릿 엔진 사용해서 Txt도 처리하도록 Config 파일 설정
+    // Thymeleaf는 기본적으로 HTML을 처리할 수 있으므로 이 파일과 관련 X
+    // SMS 템플릿을 처리할 때만 사용
+    @Bean
+    public SpringTemplateEngine textTemplateEngine() {
+        SpringTemplateEngine templateEngine = new SpringTemplateEngine();
+
+        ClassLoaderTemplateResolver templateResolver = new ClassLoaderTemplateResolver();
+        templateResolver.setPrefix("/templates/"); // 경로 설정
+        templateResolver.setSuffix(".txt");        // .txt 파일 읽기
+        templateResolver.setTemplateMode(TemplateMode.TEXT); // 텍스트 모드
+        templateResolver.setCharacterEncoding("UTF-8");
+        templateResolver.setCacheable(false); // 개발 중엔 캐시 끄기
+
+        templateEngine.setTemplateResolver(templateResolver);
+        return templateEngine;
+    }
+}

--- a/src/main/java/com/example/only4_kafka/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/only4_kafka/global/exception/ErrorCode.java
@@ -82,8 +82,9 @@ public enum ErrorCode {
 
     ILLEGAL_ARGUMENT_EXCEPTION_ERROR(400, "B997", "Illegal Argument Exception Error"),
 
-    ARRAY_INDEX_OUT_OF_BOUNDS_ERROR(400, "B996", "Array Index Out of Bounds Error")
+    ARRAY_INDEX_OUT_OF_BOUNDS_ERROR(400, "B996", "Array Index Out of Bounds Error"),
 
+    SMS_SEND_FAILED(500, "S001", "SMS 발송에 실패했습니다.")
     ;
 
     /**

--- a/src/main/java/com/example/only4_kafka/infrastructure/sms/SmsClient.java
+++ b/src/main/java/com/example/only4_kafka/infrastructure/sms/SmsClient.java
@@ -1,0 +1,30 @@
+package com.example.only4_kafka.infrastructure.sms;
+
+import com.example.only4_kafka.global.exception.BusinessException;
+import com.example.only4_kafka.global.exception.ErrorCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+@Slf4j
+@Component
+public class SmsClient {
+    public void send(String phoneNumber, Long billId, String smsBillContent) {
+        // 이미 청구서가 발송되었는지 확인하기
+        // 문제점 : '아직 발송중'인 경우 체킹 가능? => 발송은 했으나 도착 여부는 모를 때
+
+        // SMS 발송 시도
+        int random = ThreadLocalRandom.current().nextInt(100);
+
+        // 뽑은 숫자가 0이면 실패 (확률 1/100)
+        if (random == 0) {
+            log.warn("[SMS 발송 실패] (BillId: {}, phone: {})", billId, phoneNumber);
+
+            // SMS 발송 실패 예외처리
+            throw new BusinessException(ErrorCode.SMS_SEND_FAILED);
+        }
+
+        log.info("[SMS 발송 성공] (BillId: {}, phone: {}, smsBillContent: {})", billId, phoneNumber, smsBillContent);
+    }
+}

--- a/src/main/java/com/example/only4_kafka/infrastructure/sms/SmsClient.java
+++ b/src/main/java/com/example/only4_kafka/infrastructure/sms/SmsClient.java
@@ -1,20 +1,23 @@
 package com.example.only4_kafka.infrastructure.sms;
 
+import com.example.only4_kafka.domain.bill_notification.BillNotificationRepository;
 import com.example.only4_kafka.global.exception.BusinessException;
 import com.example.only4_kafka.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 import java.util.concurrent.ThreadLocalRandom;
 
+
 @Slf4j
+@RequiredArgsConstructor
 @Component
 public class SmsClient {
-    public void send(String phoneNumber, Long billId, String smsBillContent) {
-        // 이미 청구서가 발송되었는지 확인하기
-        // 문제점 : '아직 발송중'인 경우 체킹 가능? => 발송은 했으나 도착 여부는 모를 때
+    private final BillNotificationRepository billNotificationRepository;
 
-        // SMS 발송 시도
+    public void send(String phoneNumber, Long billId, String smsBillContent) {
+        // SMS 발송 시도 : 일단 1% 확률로 실패 처리
         int random = ThreadLocalRandom.current().nextInt(100);
 
         // 뽑은 숫자가 0이면 실패 (확률 1/100)

--- a/src/main/java/com/example/only4_kafka/listener/SmsRequestListener.java
+++ b/src/main/java/com/example/only4_kafka/listener/SmsRequestListener.java
@@ -3,12 +3,10 @@ package com.example.only4_kafka.listener;
 import com.example.only4_kafka.config.properties.KafkaTopicsProperties;
 import com.example.only4_kafka.event.SmsSendRequestEvent;
 import com.example.only4_kafka.service.SmsSendService;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 
 @Component
-@Slf4j
 public class SmsRequestListener {
     private final KafkaTopicsProperties topics;
     private final SmsSendService smsSendService;
@@ -28,6 +26,6 @@ public class SmsRequestListener {
 //            groupId = "#{@kafkaTopicsProperties.groupId}"
     )
     public void listen(SmsSendRequestEvent message) {
-        smsSendService.send(message);
+        smsSendService.processSms(message);
     }
 }

--- a/src/main/java/com/example/only4_kafka/service/SmsSendService.java
+++ b/src/main/java/com/example/only4_kafka/service/SmsSendService.java
@@ -1,12 +1,92 @@
 package com.example.only4_kafka.service;
 
+import com.example.only4_kafka.domain.bill.Bill;
+import com.example.only4_kafka.domain.bill.BillRepository;
+import com.example.only4_kafka.domain.bill.BillSendStatus;
+import com.example.only4_kafka.domain.bill_notification.BillChannel;
+import com.example.only4_kafka.domain.bill_notification.BillNotification;
+import com.example.only4_kafka.domain.bill_notification.BillNotificationRepository;
+import com.example.only4_kafka.domain.bill_notification.BillNotificationStatus;
+import com.example.only4_kafka.domain.bill_send.SmsBillDto;
 import com.example.only4_kafka.event.SmsSendRequestEvent;
+import com.example.only4_kafka.infrastructure.sms.SmsClient;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.thymeleaf.context.Context;
+import org.thymeleaf.spring6.SpringTemplateEngine;
 
 @Slf4j
 @Service
 public class SmsSendService {
-    public void send(SmsSendRequestEvent message) {
+    private final BillRepository billRepository;
+    private final BillNotificationRepository billNotificationRepository;
+    private final SmsClient smsClient;
+    private final SpringTemplateEngine templateEngine;
+
+    public SmsSendService(BillRepository billRepository, BillNotificationRepository billNotificationRepository,
+                          SmsClient smsClient, @Qualifier("textTemplateEngine") SpringTemplateEngine templateEngine) {
+        this.billRepository = billRepository;
+        this.billNotificationRepository = billNotificationRepository;
+        this.smsClient = smsClient;
+        this.templateEngine = templateEngine;
+    }
+
+    @Transactional
+    public void processSms(SmsSendRequestEvent event) {
+        // 1. event에서 memberId, billId 추출
+        Long billId = event.billId();
+
+        // 2. 이미 해당 청구서가 발송되었는지 확인
+        // 문제점 : '아직 발송중'인 경우 체킹 가능? => 발송은 했으나 도착 여부는 모를 때
+        boolean isAlreadySent = billNotificationRepository.existsByBillIdAndSendStatus(billId, BillNotificationStatus.SENT);
+
+        if(isAlreadySent) {
+            log.info("[중복 방지] 이미 발송 완료된 청구서입니다. (BillId: {})", billId);
+            // 추후 nonRetryableError로 설정하고 재시도 안하는 로직 추가하기
+            // 예외 처리로 변경하기
+            return;
+        }
+
+        // 3. 필요한 정보 추출해 청구서 Dto 생성
+        SmsBillDto smsBillDto = billRepository.findSmsBillDtoById(billId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 청구서가 없습니다."));
+
+        // 4. Dto 기반으로 String Teplate 생성
+        String smsBillContent = getSmsBillContent(smsBillDto);
+
+        // 4. SMS 발송 (전화번호, 청구서id, 내용)
+        smsClient.send(smsBillDto.phoneNumber(), smsBillDto.billId(), smsBillContent);
+
+        // 5. 청구서 발송 상태 변경
+        updateBillSendStatus(billId);
+
+    }
+
+    // 질문) bill의 sendStatus vs bill_Notification의 sendStatus는 각각 어떤 용도인가?
+    private void updateBillSendStatus(Long billId) {
+        // 청구서 조회
+        Bill bill = billRepository.findById(billId)
+                .orElseThrow(() -> new IllegalArgumentException("청구서 엔티티가 없습니다."));
+
+        // 청구서 발송 상태 변경
+        bill.changeSendStatus(BillSendStatus.SENT);
+
+        // 청구서 발송 이력 조회
+        BillNotification notification = billNotificationRepository.findById(billId)
+                .orElseThrow(() -> new IllegalArgumentException("청구서 발송 이력이 없습니다."));
+
+        // 청구서 발송 이력 상태 변경
+        notification.changeSendStatus(BillNotificationStatus.SENT);
+
+        log.info("청구서 발송 상태 업데이트 완료 (BillId: {}, Bill.sendStatus: {}, BillNotification.sendStatus: {})", billId, bill.getBillSendStatus(), notification.getSendStatus());
+    }
+
+    // 청구서 Dto -> SMS 텍스트로 변환
+    private String getSmsBillContent(SmsBillDto smsBillDto) {
+        Context context = new Context();
+        context.setVariable("invoice", smsBillDto); // 템플릿에서 invoice로 꺼냄
+        return templateEngine.process("SmsBill", context); // SmsBill.txt 파일 읽어서 처리
     }
 }

--- a/src/main/resources/templates/SmsBill.txt
+++ b/src/main/resources/templates/SmsBill.txt
@@ -1,0 +1,33 @@
+LG U+ 모바일명세서
+[[(${invoice.billingYear})]]년 [[(${invoice.billingMonth})]]월
+
+고객명         [[(${invoice.customerName})]]
+모바일 서비스번호
+               [[(${invoice.phoneNumber})]]
+명세서번호     [[(${invoice.invoiceNumber})]]
+이용기간       [[(${invoice.usagePeriod})]]
+작성일자       [[(${invoice.issueDate})]]
+
+납부하실 금액   [[(${#numbers.formatInteger(invoice.totalPayment, 0, 'COMMA')})]] 원
+
+[당월요금]      [[(${#numbers.formatInteger(invoice.totalPayment, 0, 'COMMA')})]] 원
+이용금액        [[(${#numbers.formatInteger(invoice.usageAmount, 0, 'COMMA')})]] 원
+할인금액       -[[(${#numbers.formatInteger(invoice.discountAmount, 0, 'COMMA')})]] 원
+[미납요금]           [[(${#numbers.formatInteger(invoice.unpaidAmount, 0, 'COMMA')})]] 원
+
+[당월요금] 상세내역
+월정액          [[(${#numbers.formatInteger(invoice.monthlyFee, 0, 'COMMA')})]] 원
+10원미만할인요금    -[[(${#numbers.formatInteger(invoice.roundingDiscount, 0, 'COMMA')})]] 원
+부가가치세       [[(${#numbers.formatInteger(invoice.vat, 0, 'COMMA')})]] 원
+
+납부정보
+[[(${invoice.paymentType == 'CARD' ? '카드주' : '예금주'})]]          [[(${invoice.paymentHolder})]]
+[[(${invoice.paymentType == 'CARD' ? '카드명' : '은행명'})]]          [[(${invoice.paymentName})]]
+[[(${invoice.paymentType == 'CARD' ? '카드번호' : '계좌번호'})]]        [[(${invoice.paymentNumber})]]
+납기일          [[(${invoice.dueDate})]]
+
+명세서 작성일자 이후 납부하신 요금은
+[납부하실 금액]에 반영되지 않을 수
+있습니다.
+
+문의: 1544-0010


### PR DESCRIPTION
## 📝 작업 내용
> SMS Consumer 세부 로직 코드 작성

- [x] 필요한 도메인 import
- [x] SMS 청구서 Dto  & 템플릿 생성
- [x] SMS 청구서 모의 발송 로직 작성

### 📷 스크린샷


## ☑️ 체크 리스트
> 체크  리스트를 확인해주세요
- [x] 테스트는 잘 통과했나요?
- [x] 충돌을 해결했나요?
- [x] 이슈는 등록했나요?
- [x] 라벨은 등록했나요?


## #️⃣ 연관된 이슈
> closes #10 


## 💬 리뷰 요구사항

### SMS 청구서 Dto 생성 방식 (BillRepository)
- 현재 방법 : BillRepository에서 JPQL로 Member, Bill 테이블을 JOIN 시켜서 Dto를 리턴하게 함
- 기존에 생각한 방법 : Member, Bill Repository에서 각각 조회 후 Service 로직에서 직접 Dto 생성

이 방법이 성능 측면에서 더 나은 방법일까요?

