### PR TITLE
[Feat]: SmsConsumerConfig 관련 작업 수행

### DIFF
--- a/src/main/java/com/example/only4_kafka/config/kafka/KafkaConsumerConfig.java
+++ b/src/main/java/com/example/only4_kafka/config/kafka/KafkaConsumerConfig.java
@@ -3,9 +3,12 @@ package com.example.only4_kafka.config.kafka;
 import com.example.only4_kafka.config.properties.RetryProperties;
 import com.example.only4_kafka.constant.KafkaPropertiesConstant;
 import com.example.only4_kafka.event.EmailSendRequestEvent;
+import com.example.only4_kafka.event.SmsSendRequestEvent;
+import com.example.only4_kafka.service.failure.SmsFailureHandler;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
 import org.springframework.context.annotation.Bean;
@@ -13,6 +16,8 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.listener.DeadLetterPublishingRecoverer;
 import org.springframework.kafka.listener.DefaultErrorHandler;
 import org.springframework.kafka.support.ExponentialBackOffWithMaxRetries;
 import org.springframework.kafka.support.serializer.JsonDeserializer;
@@ -24,8 +29,10 @@ import java.util.Map;
 @RequiredArgsConstructor
 @Configuration
 public class KafkaConsumerConfig {
-
+    private final KafkaTemplate<String, Object> kafkaTemplate;
     private final RetryProperties retryProperties;
+    private static final String BOOTSTRAP_SERVERS = "localhost:9092";
+    private final SmsFailureHandler smsFailureHandler;
 
     // ConsumerFactory: 메시지를 어떻게 읽을지 설정
     @Bean
@@ -43,6 +50,25 @@ public class KafkaConsumerConfig {
         return new DefaultKafkaConsumerFactory<>(props, new StringDeserializer(), valueDeserializer); // 설정 다 모아서 Factory 생성
     }
 
+    // smsConsumerFactory : KafkaProperties 안 쓰는 방식으로
+    @Bean
+    public ConsumerFactory<String, SmsSendRequestEvent> smsConsumerFactory() {
+        Map<String, Object> props = new HashMap<>();
+
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, BOOTSTRAP_SERVERS);
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest"); // 메시지 항상 처음부터 읽음 (데이터 유실 방지)
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+        props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false); // 오프셋 자동 커밋 비활성화
+
+        // 보안 설정 / JSON을 아무 클래스로나 변환하면 위험 / 해당 패키지 클래스만 허용 지정
+        JsonDeserializer<SmsSendRequestEvent> valueDeserializer =
+                new JsonDeserializer<>(SmsSendRequestEvent.class);
+        valueDeserializer.addTrustedPackages(KafkaPropertiesConstant.EVENT_PACAKGE);
+
+        return new DefaultKafkaConsumerFactory<>(props, new StringDeserializer(), valueDeserializer); // 설정 다 모아서 Factory 생성
+    }
+
     // @KafkaListener 실행하는 컨테이너 만드는 공장
     @Bean
     public ConcurrentKafkaListenerContainerFactory<String, EmailSendRequestEvent>
@@ -52,6 +78,18 @@ public class KafkaConsumerConfig {
                 new ConcurrentKafkaListenerContainerFactory<>();
         factory.setConsumerFactory(emailConsumerFactory);
         factory.setCommonErrorHandler(emailErrorHandler());
+        return factory;
+    }
+
+    // Sms용 ContainerFactory
+    @Bean("smsListenerContainerFactory")
+    public ConcurrentKafkaListenerContainerFactory<String, SmsSendRequestEvent> smsFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, SmsSendRequestEvent> factory =
+                new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(smsConsumerFactory());
+        factory.setConcurrency(3); // Sms 컨슈머 3개
+        factory.setCommonErrorHandler(smsErrorHandler());
+
         return factory;
     }
 
@@ -69,6 +107,28 @@ public class KafkaConsumerConfig {
         errorHandler.setRetryListeners((record, ex, deliveryAttempt) ->
                 log.warn("이메일 처리 재시도. attempt={}, topic={}, offset={}",
                         deliveryAttempt, record.topic(), record.offset())
+        );
+
+        return errorHandler;
+    }
+
+    // Sms 재시도 정책 설정
+    @Bean
+    public DefaultErrorHandler smsErrorHandler() {
+        // 재시도 정책 생성
+        int maxAttempts = retryProperties.smsMaxAttempts();
+        ExponentialBackOffWithMaxRetries backOff = new ExponentialBackOffWithMaxRetries(maxAttempts - 1);
+        backOff.setInitialInterval(retryProperties.initialIntervalMs());
+        backOff.setMultiplier(retryProperties.multiplier());
+        backOff.setMaxInterval(retryProperties.maxIntervalMs());
+
+        // ErrorHandler 생성 (Recoverer + BackOff)
+        DefaultErrorHandler errorHandler = new DefaultErrorHandler(smsFailureHandler, backOff);
+
+        // 재시도 로그 리스너
+        errorHandler.setRetryListeners((record, ex, deliveryAttempt) ->
+                log.warn("SMS 처리 재시도. attempt={}, topic={}, error={}",
+                        deliveryAttempt, record.topic(), ex.getMessage())
         );
 
         return errorHandler;

--- a/src/main/java/com/example/only4_kafka/domain/bill/BillRepository.java
+++ b/src/main/java/com/example/only4_kafka/domain/bill/BillRepository.java
@@ -6,12 +6,13 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
 import java.util.Optional;
 
 @Repository
 public interface BillRepository extends JpaRepository<Bill, Long> {
     @Query("""
-        SELECT SmsBillDto(
+        SELECT new com.example.only4_kafka.domain.bill_send.SmsBillDto(
             m.name,
             m.phoneNumber,
             m.doNotDisturbStartTime,
@@ -29,11 +30,11 @@ public interface BillRepository extends JpaRepository<Bill, Long> {
             b.unpaidAmount,
             b.totalBilledAmount,
             b.vat,
-            CURRENT_DATE
+            :now
         )
         FROM Bill b
         JOIN b.member m
         WHERE b.id = :billId
     """)
-    Optional<SmsBillDto> findSmsBillDtoById(@Param("billId") Long billId);
+    Optional<SmsBillDto> findSmsBillDtoById(@Param("billId") Long billId, @Param("now") LocalDate now);
 }

--- a/src/main/java/com/example/only4_kafka/listener/SmsRequestListener.java
+++ b/src/main/java/com/example/only4_kafka/listener/SmsRequestListener.java
@@ -18,7 +18,8 @@ public class SmsRequestListener {
 
     @KafkaListener(
             topics = "${app.kafka.topics.sms-request}",
-            groupId = "${app.kafka.topics.group-id}"
+            groupId = "${app.kafka.topics.group-id}",
+            containerFactory = "smsListenerContainerFactory"
 
             // 노션에 적힌 아래 방법은 에러가 떠서 바꿈
             // A component required a bean named 'kafkaTopicsProperties' that could not be found.

--- a/src/main/java/com/example/only4_kafka/service/SmsSendService.java
+++ b/src/main/java/com/example/only4_kafka/service/SmsSendService.java
@@ -33,7 +33,7 @@ public class SmsSendService {
         this.templateEngine = templateEngine;
     }
 
-    @Transactional
+
     public void processSms(SmsSendRequestEvent event) {
         // 1. event에서 memberId, billId 추출
         Long billId = event.billId();
@@ -65,6 +65,7 @@ public class SmsSendService {
     }
 
     // 질문) bill의 sendStatus vs bill_Notification의 sendStatus는 각각 어떤 용도인가?
+    @Transactional
     private void updateBillSendStatus(Long billId) {
         // 청구서 조회
         Bill bill = billRepository.findById(billId)

--- a/src/main/java/com/example/only4_kafka/service/SmsSendService.java
+++ b/src/main/java/com/example/only4_kafka/service/SmsSendService.java
@@ -50,7 +50,7 @@ public class SmsSendService {
         }
 
         // 3. 필요한 정보 추출해 청구서 Dto 생성
-        SmsBillDto smsBillDto = billRepository.findSmsBillDtoById(billId)
+        SmsBillDto smsBillDto = billRepository.findSmsBillDtoById(billId, java.time.LocalDate.now())
                 .orElseThrow(() -> new IllegalArgumentException("해당 청구서가 없습니다."));
 
         // 4. Dto 기반으로 String Teplate 생성

--- a/src/main/java/com/example/only4_kafka/service/failure/SmsFailureHandler.java
+++ b/src/main/java/com/example/only4_kafka/service/failure/SmsFailureHandler.java
@@ -1,0 +1,19 @@
+package com.example.only4_kafka.service.failure;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.common.TopicPartition;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.listener.DeadLetterPublishingRecoverer;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class SmsFailureHandler extends DeadLetterPublishingRecoverer {
+    private static final String DLT_TOPIC = "notification.dlt"; // KafkaTopicConfig에서 읽어오는 걸로 변경 예정
+
+    public SmsFailureHandler(KafkaTemplate<String, Object> kafkaTemplate) {
+        super(kafkaTemplate, (record, ex) -> {
+            return new TopicPartition(DLT_TOPIC, -1);
+        });
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,6 +16,9 @@ spring:
 
   # [공통] Kafka Consumer 설정 (주소 제외)
   kafka:
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
     consumer:
 #      group-id: only4-consumer-group
       # earliest: 큐에 쌓인 옛날 메시지부터 읽기 / latest: 지금부터 온 것만 읽기


### PR DESCRIPTION
## 📝 작업 내용
> Sms Consume에 관한 Config 파일 내용 작성
> SMS 재시도 정책 적용 및 FailureHandler 작성

- [x] application.yml => DLT Produce 위해 producer 설정 추가 
- [x] KafkaConsumerConfig => SMS Consumer 설정 추가
- [x] SmsFailureHandler => SMS 재시도 실패시 DLT에 Topic 발행
- [x] BillRepository => SmsBillDTO 가져오는 JQPL 구문 수정
- [x] SmsRequestListener => @KafkaListener에 containerFactory 추가
- [x] SmsSendService => @Transactiona DB 사용 함수에 적용 & JPQL 변경에 따른 코드 변경

### 📷 스크린샷


## ☑️ 체크 리스트
> 체크  리스트를 확인해주세요
- [x] 테스트는 잘 통과했나요? => kafka-ui로 DLT 토픽 발행 확인
- [x] 충돌을 해결했나요?
- [x] 이슈는 등록했나요?
- [x] 라벨은 등록했나요?


## #️⃣ 연관된 이슈
> closes #12 


## 💬 리뷰 요구사항
