### PR TITLE
[FIX]: SMS 발송 성공해도 재시도하는 버그 해결

### DIFF
--- a/src/main/java/com/example/only4_kafka/domain/common/BaseEntity.java
+++ b/src/main/java/com/example/only4_kafka/domain/common/BaseEntity.java
@@ -2,6 +2,8 @@ package com.example.only4_kafka.domain.common;
 
 import jakarta.persistence.*;
 import lombok.Getter;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -22,6 +24,7 @@ public abstract class BaseEntity {
     private LocalDateTime modifiedDate;
 
     @Enumerated(value = EnumType.STRING)
+    @JdbcTypeCode(SqlTypes.NAMED_ENUM)
     @Column(name = "status", nullable = false)
     Status status = Status.ACTIVE;
 

--- a/src/main/java/com/example/only4_kafka/listener/SmsRequestListener.java
+++ b/src/main/java/com/example/only4_kafka/listener/SmsRequestListener.java
@@ -2,7 +2,7 @@ package com.example.only4_kafka.listener;
 
 import com.example.only4_kafka.config.properties.KafkaTopicsProperties;
 import com.example.only4_kafka.event.SmsSendRequestEvent;
-import com.example.only4_kafka.service.SmsSendService;
+import com.example.only4_kafka.service.sms.SmsSendService;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 

--- a/src/main/java/com/example/only4_kafka/service/SmsSendService.java
+++ b/src/main/java/com/example/only4_kafka/service/SmsSendService.java
@@ -75,13 +75,13 @@ public class SmsSendService {
         bill.changeSendStatus(BillSendStatus.SENT);
 
         // 청구서 발송 이력 조회
-        BillNotification notification = billNotificationRepository.findById(billId)
-                .orElseThrow(() -> new IllegalArgumentException("청구서 발송 이력이 없습니다."));
+//        BillNotification notification = billNotificationRepository.findById(billId)
+//                .orElseThrow(() -> new IllegalArgumentException("청구서 발송 이력이 없습니다."));
+//
+//        // 청구서 발송 이력 상태 변경
+//        notification.changeSendStatus(BillNotificationStatus.SENT);
 
-        // 청구서 발송 이력 상태 변경
-        notification.changeSendStatus(BillNotificationStatus.SENT);
-
-        log.info("청구서 발송 상태 업데이트 완료 (BillId: {}, Bill.sendStatus: {}, BillNotification.sendStatus: {})", billId, bill.getBillSendStatus(), notification.getSendStatus());
+        log.info("청구서 발송 상태 업데이트 완료 (BillId: {}, Bill.sendStatus: {})", billId, bill.getBillSendStatus()); // , notification.getSendStatus()
     }
 
     // 청구서 Dto -> SMS 텍스트로 변환

--- a/src/main/java/com/example/only4_kafka/service/sms/SmsSendService.java
+++ b/src/main/java/com/example/only4_kafka/service/sms/SmsSendService.java
@@ -1,19 +1,15 @@
-package com.example.only4_kafka.service;
+package com.example.only4_kafka.service.sms;
 
-import com.example.only4_kafka.domain.bill.Bill;
 import com.example.only4_kafka.domain.bill.BillRepository;
-import com.example.only4_kafka.domain.bill.BillSendStatus;
-import com.example.only4_kafka.domain.bill_notification.BillChannel;
-import com.example.only4_kafka.domain.bill_notification.BillNotification;
 import com.example.only4_kafka.domain.bill_notification.BillNotificationRepository;
 import com.example.only4_kafka.domain.bill_notification.BillNotificationStatus;
 import com.example.only4_kafka.domain.bill_send.SmsBillDto;
 import com.example.only4_kafka.event.SmsSendRequestEvent;
 import com.example.only4_kafka.infrastructure.sms.SmsClient;
+import com.example.only4_kafka.service.sms.writer.SmsSendStatusWriter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import org.thymeleaf.context.Context;
 import org.thymeleaf.spring6.SpringTemplateEngine;
 
@@ -24,13 +20,16 @@ public class SmsSendService {
     private final BillNotificationRepository billNotificationRepository;
     private final SmsClient smsClient;
     private final SpringTemplateEngine templateEngine;
+    private final SmsSendStatusWriter smsSendStatusWriter;
 
     public SmsSendService(BillRepository billRepository, BillNotificationRepository billNotificationRepository,
-                          SmsClient smsClient, @Qualifier("textTemplateEngine") SpringTemplateEngine templateEngine) {
+                          SmsClient smsClient, @Qualifier("textTemplateEngine") SpringTemplateEngine templateEngine,
+                          SmsSendStatusWriter smsSendStatusWriter, SmsSendStatusWriter smsSendStatusWriter1) {
         this.billRepository = billRepository;
         this.billNotificationRepository = billNotificationRepository;
         this.smsClient = smsClient;
         this.templateEngine = templateEngine;
+        this.smsSendStatusWriter = smsSendStatusWriter;
     }
 
 
@@ -60,28 +59,8 @@ public class SmsSendService {
         smsClient.send(smsBillDto.phoneNumber(), smsBillDto.billId(), smsBillContent);
 
         // 5. 청구서 발송 상태 변경
-        updateBillSendStatus(billId);
+        smsSendStatusWriter.updateBillSendStatus(billId);
 
-    }
-
-    // 질문) bill의 sendStatus vs bill_Notification의 sendStatus는 각각 어떤 용도인가?
-    @Transactional
-    private void updateBillSendStatus(Long billId) {
-        // 청구서 조회
-        Bill bill = billRepository.findById(billId)
-                .orElseThrow(() -> new IllegalArgumentException("청구서 엔티티가 없습니다."));
-
-        // 청구서 발송 상태 변경
-        bill.changeSendStatus(BillSendStatus.SENT);
-
-        // 청구서 발송 이력 조회
-//        BillNotification notification = billNotificationRepository.findById(billId)
-//                .orElseThrow(() -> new IllegalArgumentException("청구서 발송 이력이 없습니다."));
-//
-//        // 청구서 발송 이력 상태 변경
-//        notification.changeSendStatus(BillNotificationStatus.SENT);
-
-        log.info("청구서 발송 상태 업데이트 완료 (BillId: {}, Bill.sendStatus: {})", billId, bill.getBillSendStatus()); // , notification.getSendStatus()
     }
 
     // 청구서 Dto -> SMS 텍스트로 변환

--- a/src/main/java/com/example/only4_kafka/service/sms/writer/SmsSendStatusWriter.java
+++ b/src/main/java/com/example/only4_kafka/service/sms/writer/SmsSendStatusWriter.java
@@ -1,0 +1,37 @@
+package com.example.only4_kafka.service.sms.writer;
+
+import com.example.only4_kafka.domain.bill.Bill;
+import com.example.only4_kafka.domain.bill.BillRepository;
+import com.example.only4_kafka.domain.bill.BillSendStatus;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SmsSendStatusWriter {
+    private final BillRepository billRepository;
+
+
+    // 질문) bill의 sendStatus vs bill_Notification의 sendStatus는 각각 어떤 용도인가?
+    @Transactional
+    public void updateBillSendStatus(Long billId) {
+        // 청구서 조회
+        Bill bill = billRepository.findById(billId)
+                .orElseThrow(() -> new IllegalArgumentException("청구서 엔티티가 없습니다."));
+
+        // 청구서 발송 상태 변경
+        bill.changeSendStatus(BillSendStatus.SENT);
+
+        // 청구서 발송 이력 조회
+//        BillNotification notification = billNotificationRepository.findById(billId)
+//                .orElseThrow(() -> new IllegalArgumentException("청구서 발송 이력이 없습니다."));
+//
+//        // 청구서 발송 이력 상태 변경
+//        notification.changeSendStatus(BillNotificationStatus.SENT);
+
+        log.info("청구서 발송 상태 업데이트 완료 (BillId: {}, Bill.sendStatus: {})", billId, bill.getBillSendStatus()); // , notification.getSendStatus()
+    }
+}


### PR DESCRIPTION
## 📝 작업 내용
> SMS 발송 성공해도 재시도하는 버그 해결함
> 원인: SMS 발송 이후 Bill, BillNotification의 SendStatus 업데이트하는 곳에서 BillNotification의 Row가 없어서 발생하는 문제
> 해결: Bill의 sendStatus만 업데이트하도록 주석 처리함

- [x] SmsSendService
- [x] BaseEntity
- [x] SmsSendStatusWriter
- [x] SmsRequestListener

### 📷 스크린샷


## ☑️ 체크 리스트
> 체크  리스트를 확인해주세요
- [x] 테스트는 잘 통과했나요?
- [x] 충돌을 해결했나요?
- [x] 이슈는 등록했나요?
- [x] 라벨은 등록했나요?


## #️⃣ 연관된 이슈
> closes #22


## 💬 리뷰 요구사항

