### PR TITLE
[FEAT]: SMS 청구서 DTO 구조 변경

### DIFF
--- a/src/main/java/com/example/only4_kafka/domain/bill/BillRepository.java
+++ b/src/main/java/com/example/only4_kafka/domain/bill/BillRepository.java
@@ -22,14 +22,37 @@ public interface BillRepository extends JpaRepository<Bill, Long> {
             b.paymentNameSnapshot,
             b.paymentNumberSnapshot,
             b.dueDate,
-
+            
             b.id,
             b.billingYearMonth,
             b.totalAmount,
             b.totalDiscountAmount,
             b.unpaidAmount,
             b.totalBilledAmount,
+            
+            (
+                SELECT COALESCE(SUM(bi.amount), 0)
+                FROM BillItem bi
+                WHERE bi.bill.id = b.id
+                  AND bi.itemCategory = 'SUBSCRIPTION'
+            ),
+            
+            (
+                SELECT COALESCE(SUM(bi.amount), 0)
+                FROM BillItem bi
+                WHERE bi.bill.id = b.id
+                  AND bi.itemCategory = 'OVER_USAGE'
+            ),
+            
+            (
+                SELECT COALESCE(SUM(bi.amount), 0)
+                FROM BillItem bi
+                WHERE bi.bill.id = b.id
+                  AND bi.itemCategory = 'ONE_TIME_PURCHASE'
+            ),
+            
             b.vat,
+            
             :now
         )
         FROM Bill b

--- a/src/main/java/com/example/only4_kafka/domain/bill_send/SmsBillDto.java
+++ b/src/main/java/com/example/only4_kafka/domain/bill_send/SmsBillDto.java
@@ -26,6 +26,9 @@ public record SmsBillDto(
         BigDecimal totalDiscountAmount, // 총 할인 금액
         BigDecimal unpaidAmount, // 미납금
         BigDecimal totalBilledAmount, // 총 청구 금액 (실제 납부)
+        BigDecimal totalMonthlyAmount, // 월정액
+        BigDecimal totalOverageAmount, // 초과 사용료
+        BigDecimal totalMicroAmount, // 소액 결제
         BigDecimal vat, // 부가가치세
         LocalDate createdDate // 작성 일자
 ) {

--- a/src/main/java/com/example/only4_kafka/service/sms/SmsSendService.java
+++ b/src/main/java/com/example/only4_kafka/service/sms/SmsSendService.java
@@ -55,6 +55,8 @@ public class SmsSendService {
         // 4. Dto 기반으로 String Teplate 생성
         String smsBillContent = getSmsBillContent(smsBillDto);
 
+        log.info("[SMS 청구서]\n {}", smsBillContent);
+
         // 4. SMS 발송 (전화번호, 청구서id, 내용)
         smsClient.send(smsBillDto.phoneNumber(), smsBillDto.billId(), smsBillContent);
 

--- a/src/main/resources/templates/SmsBill.txt
+++ b/src/main/resources/templates/SmsBill.txt
@@ -12,12 +12,14 @@ LG U+ 모바일명세서
 
 [당월요금]      [[${#numbers.formatInteger(invoice.totalBilledAmount, 0, 'COMMA')}]] 원
 이용금액        [[${#numbers.formatInteger(invoice.totalAmount, 0, 'COMMA')}]] 원
+미납요금      [[${#numbers.formatInteger(invoice.unpaidAmount, 0, 'COMMA')}]] 원
+부가가치세      [[${#numbers.formatInteger(invoice.vat, 0, 'COMMA')}]] 원
 할인금액       -[[${#numbers.formatInteger(invoice.totalDiscountAmount, 0, 'COMMA')}]] 원
-[미납요금]      [[${#numbers.formatInteger(invoice.unpaidAmount, 0, 'COMMA')}]] 원
 
 [당월요금] 상세내역
-기본사용료      [[${#numbers.formatInteger(invoice.totalAmount, 0, 'COMMA')}]] 원
-부가가치세      [[${#numbers.formatInteger(invoice.vat, 0, 'COMMA')}]] 원
+월정액      [[${#numbers.formatInteger(invoice.totalMonthlyAmount, 0, 'COMMA')}]] 원
+초과 사용료      [[${#numbers.formatInteger(invoice.totalOverageAmount, 0, 'COMMA')}]] 원
+소액 결제      [[${#numbers.formatInteger(invoice.totalMicroAmount, 0, 'COMMA')}]] 원
 
 납부정보
 납부자명        [[${invoice.paymentOwnerName}]]


### PR DESCRIPTION
## 📝 작업 내용
> SMS 청구서 DTO 및 템플릿 변경

- [x] 월정액 추가
- [x] 초과 사용료 추가
- [x] 소액 결제 추가

### 📷 스크린샷


## ☑️ 체크 리스트
> 체크  리스트를 확인해주세요
- [x] 테스트는 잘 통과했나요?
- [x] 충돌을 해결했나요?
- [x] 이슈는 등록했나요?
- [x] 라벨은 등록했나요?


## #️⃣ 연관된 이슈
> closes #25 


## 💬 리뷰 요구사항
> 원래 월정액만 추가하려했으나 SMS 템플릿에서 당월 요금, 상세 내역 금액의 불일치처럼 보여서 세부 항목에 요소 추가함
