### PR TITLE
[FIX]: 최근 청구서 내역 없을 시 HTML 렌더링 오류 기본값 설정으로 해결

### DIFF
--- a/src/main/java/com/example/only4_kafka/service/email/EmailSendService.java
+++ b/src/main/java/com/example/only4_kafka/service/email/EmailSendService.java
@@ -40,6 +40,7 @@ public class EmailSendService {
         String htmlContent = emailTemplateRenderer.render(emailInvoiceTemplateDto);
         log.info("6) HTML 렌더링 완료. memberId={}, billId={}, contentLength={}",
                 event.memberId(), event.billId(), htmlContent.length());
+        log.info("6-1) HTML 청구서 결과 \n {}", htmlContent);
 
         // 4. Send email
         String encryptedEmail = emailInvoiceReadResult.memberBill().memberEmail();

--- a/src/main/java/com/example/only4_kafka/service/email/mapper/EmailInvoiceMapper.java
+++ b/src/main/java/com/example/only4_kafka/service/email/mapper/EmailInvoiceMapper.java
@@ -108,10 +108,11 @@ public class EmailInvoiceMapper {
         );
     }
 
-    // 최근 4개월 변환
+    // 최근 4개월 변환 (항상 4개 보장, 오래된 순 정렬)
     private List<EmailInvoiceTemplateDto.RecentMonth> mapRecentMonths(List<RecentBillRow> recentBillRowList) {
         List<EmailInvoiceTemplateDto.RecentMonth> recentMonthList = new ArrayList<>();
 
+        // DB 조회 결과 변환 (DESC 정렬되어 있음)
         for (RecentBillRow recentBillRow : recentBillRowList) {
             recentMonthList.add(new EmailInvoiceTemplateDto.RecentMonth(
                     formatYearMonth(recentBillRow.billingYearMonth()),
@@ -124,7 +125,28 @@ public class EmailInvoiceMapper {
             ));
         }
 
+        // 4개 미만이면 빈 데이터로 채우기 (템플릿에서 인덱스 접근 시 에러 방지)
+        while (recentMonthList.size() < EmailConstant.RECENT_MONTHS_COUNT) {
+            recentMonthList.add(createEmptyRecentMonth());
+        }
+
+        // 오래된 순으로 정렬 (DB는 DESC, 템플릿은 ASC 필요)
+        java.util.Collections.reverse(recentMonthList);
+
         return recentMonthList;
+    }
+
+    // 빈 RecentMonth 생성 (데이터 없을 때 기본값)
+    private EmailInvoiceTemplateDto.RecentMonth createEmptyRecentMonth() {
+        return new EmailInvoiceTemplateDto.RecentMonth(
+                "-",
+                BigDecimal.ZERO,
+                BigDecimal.ZERO,
+                BigDecimal.ZERO,
+                BigDecimal.ZERO,
+                BigDecimal.ZERO,
+                BigDecimal.ZERO
+        );
     }
 
     // 청구서 번호 생성


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 적어주세요

- [x] 최근 4개월 청구 내역 조회 시, 이전 청구 내역이 없는 경우 HTML 렌더링 오류 발생 -> 존재하지 않는 내역은 기본값 설정으로 해결

### 📷 스크린샷
<img width="264" height="1255" alt="image" src="https://github.com/user-attachments/assets/6e3ac7c1-0208-440b-84e8-0ca6a85ae2a4" />


## ☑️ 체크 리스트
> 체크  리스트를 확인해주세요
- [x] 테스트는 잘 통과했나요?
- [x] 충돌을 해결했나요?
- [x] 이슈는 등록했나요?
- [x] 라벨은 등록했나요?


## #️⃣ 연관된 이슈
> ex) # 이슈번호

closes #28 

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 예외 처리를 이렇게 해도 괜찮을까요? / ~~부분 주의 깊게 봐주세요

스크린샷은 로그 찍은 거 HTML로 켜 본 것입니다.

1. 글자가 좀 깨지는듯?
2. 계산 맞는지?
등
