### PR TITLE
[FIX]: EMAIL, SMS 선점 로직 분리

### DIFF
--- a/src/main/java/com/example/only4_kafka/service/BillNotificationWriter.java
+++ b/src/main/java/com/example/only4_kafka/service/BillNotificationWriter.java
@@ -30,10 +30,21 @@ public class BillNotificationWriter {
      *   - send_status = SENT (이미 완료됨)
      *   - send_status = FAILED (이미 실패 처리됨)
      */
+    /**
+     * Email 전용 선점
+     */
     @Transactional
     public Optional<BillNotificationRow> tryPreempt(Long billId, BillChannel channel, int timeoutSeconds) {
-        Optional<BillNotificationRow> preemptedRow = invoiceQueryRepository.tryPreemptForSending(billId, channel, timeoutSeconds);
-        return preemptedRow;
+        return invoiceQueryRepository.tryPreemptForSending(billId, channel, timeoutSeconds);
+    }
+
+    /**
+     * SMS 전용 선점 (EMAIL → SMS 폴백 허용)
+     * - PENDING, SENDING+타임아웃 외에도 EMAIL 채널이면 선점 허용
+     */
+    @Transactional
+    public Optional<BillNotificationRow> tryPreemptForSms(Long billId, int timeoutSeconds) {
+        return invoiceQueryRepository.tryPreemptForSms(billId, timeoutSeconds);
     }
 
     @Transactional

--- a/src/main/java/com/example/only4_kafka/service/sms/SmsSendService.java
+++ b/src/main/java/com/example/only4_kafka/service/sms/SmsSendService.java
@@ -63,10 +63,9 @@ public class SmsSendService {
     public void send(SmsSendRequestEvent event) {
         Long billId = event.billId();
 
-        // [STEP 1] 선점 시도 (가장 먼저!)
-        Optional<BillNotificationRow> preemptedOptional = billNotificationWriter.tryPreempt(
+        // [STEP 1] 선점 시도 (SMS 전용 - EMAIL → SMS 폴백 허용)
+        Optional<BillNotificationRow> preemptedOptional = billNotificationWriter.tryPreemptForSms(
                 billId,
-                BillChannel.SMS,
                 PREEMPT_TIMEOUT_SECONDS
         );
 


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 적어주세요

- [x] EMAIL, SMS 선점 로직 분리

### 📷 스크린샷


## ☑️ 체크 리스트
> 체크  리스트를 확인해주세요
- [x] 테스트는 잘 통과했나요?
- [x] 충돌을 해결했나요?
- [x] 이슈는 등록했나요?
- [x] 라벨은 등록했나요?


## #️⃣ 연관된 이슈
> ex) # 이슈번호

closes #60 

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 예외 처리를 이렇게 해도 괜찮을까요? / ~~부분 주의 깊게 봐주세요

EMAIL 실패 시 SMS 전달은 되었으나, 모두 선점에 실패하여 SMS 전송하지 않는 문제 발생.
-> EMAIL 선점과 SMS 선점 시 사용하는 쿼리를 분리하여 해결.